### PR TITLE
added via method to notification class

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -132,3 +132,8 @@ class TestNotifiable:
     def test_mail_notification_should_queue(self):
         assert self.notify.mail(ShouldQueueWelcomeNotification,
                                 to='test@email.com') is None
+
+    def test_can_send_with_via_method(self):
+        notifications = self.notify.via('mail').send(
+            ShouldQueueWelcomeNotification, to="test@email.com").called_notifications
+        assert isinstance(notifications[0], ShouldQueueWelcomeNotification)


### PR DESCRIPTION
This PR adds the ability to add a `via` and `send` method so instead of doing something like:

```python
def show(self, notify: Notify):
    notify.mail(WelcomeNotification, to="email@email.com")
    notify.slack(WelcomeNotification, to="email@email.com")
```

we can do:

```python
def show(self, notify: Notify):
    notify.via('mail', 'slack').send(WelcomeNotification, to="email@email.com")
```